### PR TITLE
Add summary of shoreline change research paper

### DIFF
--- a/Students/Kimura_Skyler.md
+++ b/Students/Kimura_Skyler.md
@@ -1,0 +1,10 @@
+# Long-Term Shoreline Change at Kailua, Hawaii, Using Regularized Single Transect
+Journal: Journal of Coastal Research, 31
+[Link to Paper](https://bioone.org/journals/journal-of-coastal-research/volume-31/issue-2/JCOASTRES-D-13-00202.1/Long-Term-Shoreline-Change-at-Kailua-Hawaii-Using-Regularized-Single/10.2112/JCOASTRES-D-13-00202.1.short)
+This paper explains why single transect method of measure coastal erosion leads to inaccurate predictions because the model to predict
+the shoreline change by calculating the shoreline statistics at short intervals which leads to high spatial frequencies. This leads to overfitting
+because it treats each measurement point on a shoreline as independent when they should highly correlate alongshore.
+The authors propose regularized single transect and B-spline as a way to improve the inaccuracies of single transect. Regularized single transect
+is the method of the mesaurement points adapting to one another creating a smoother line with less noise. And the B-spline is a way to 
+smooth out any irregularities within the data. The method proposed by the author is an improvement over the regular ST.
+Both ways are a way to using shoreline measurement points too close to each other and overfitting the data.


### PR DESCRIPTION
Added a new markdown file summarizing a research paper on shoreline change at Kailua, Hawaii, detailing the methodology and improvements proposed by the authors.